### PR TITLE
Fix for not finding MIDI port on Raspberry PI 

### DIFF
--- a/rp8000/midi.py
+++ b/rp8000/midi.py
@@ -1,5 +1,6 @@
 import time
 import rtmidi
+import re
 
 class SysEx:
 
@@ -17,7 +18,7 @@ class SysEx:
 		""" enumerate all midi devices, rtmidi doesn't have a call by name method """
 		for port, name in enumerate(self.midiout.get_ports()):
 			print(port, name)
-			if name == self.model:
+			if re.search(self.model,name)
 				return port
 		else:
 			assert False, "No MIDI port found for %s" % self.model

--- a/rp8000/midi.py
+++ b/rp8000/midi.py
@@ -18,7 +18,7 @@ class SysEx:
 		""" enumerate all midi devices, rtmidi doesn't have a call by name method """
 		for port, name in enumerate(self.midiout.get_ports()):
 			print(port, name)
-			if re.search(self.model,name)
+			if re.search(self.model,name):
 				return port
 		else:
 			assert False, "No MIDI port found for %s" % self.model


### PR DESCRIPTION
On Raspberry Pi the name of the MIDI port is 'RP8000mk2:RP8000mk2 MIDI 1 24:0' so `name == self.model` is unable to match the model. 

With re.search(self.model,name) it will find the port with the name RP8000mk2 in it